### PR TITLE
Update button behavior

### DIFF
--- a/src/components/add_users.rs
+++ b/src/components/add_users.rs
@@ -5,11 +5,12 @@ use crate::{
     api::{Chat, Profile},
     style::Theme,
 };
+use crate::widgets::click_area::click_area;
 use iced::{
     Border, Element, Length, Padding,
     alignment::Vertical,
     border,
-    widget::{Id, checkbox, column, container, mouse_area, row, scrollable, text, text_input},
+    widget::{Id, checkbox, column, container, row, scrollable, text, text_input},
 };
 
 pub fn c_add_users<'a>(
@@ -78,7 +79,7 @@ pub fn c_add_users<'a>(
         .align_y(Vertical::Center);
         user_column = user_column
             .push(
-                mouse_area(
+                click_area(
                     container(profile_row)
                         .style(|_| container::Style {
                             background: Some(theme.colors.foreground.into()),
@@ -93,12 +94,12 @@ pub fn c_add_users<'a>(
                         }),
                 )
                 .interaction(iced::mouse::Interaction::Pointer)
-                .on_release(Message::ToggleUserCheckbox(is_checked, user.0.to_string())),
+                .on_press(Message::ToggleUserCheckbox(is_checked, user.0.to_string())),
             )
             .into();
     }
 
-    mouse_area(
+    click_area(
         container(
             column![
                 row![
@@ -107,7 +108,7 @@ pub fn c_add_users<'a>(
                         .padding(10)
                         .id("search_users_input")
                         .style(|_, _| theme.stylesheet.input),
-                    mouse_area(
+                    click_area(
                         container(text("Add"))
                             .padding(Padding {
                                 top: 8.0,
@@ -124,7 +125,7 @@ pub fn c_add_users<'a>(
                             })
                     )
                     .interaction(iced::mouse::Interaction::Pointer)
-                    .on_release(
+                    .on_press(
                         if !current_chat.is_one_on_one.unwrap_or(false) {
                             Message::AddToGroupChat(
                                 current_chat.id.clone(),

--- a/src/components/chat_message.rs
+++ b/src/components/chat_message.rs
@@ -15,7 +15,8 @@ use crate::widgets::selectable_text;
 use crate::widgets::selectable_text::selectable_text;
 use iced::alignment::Vertical;
 use iced::widget::tooltip::Position;
-use iced::widget::{column, container, mouse_area, row, space, stack, svg, text, tooltip};
+use crate::widgets::click_area::click_area;
+use iced::widget::{column, container, row, space, stack, svg, text, tooltip};
 use iced::{Alignment, Border, Element, Font, Length, Padding, border, font, padding};
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -187,7 +188,7 @@ pub fn c_chat_message<'a>(
                 let mut files_row = row![].spacing(10);
 
                 for file in files {
-                    let file_container = mouse_area(
+                    let file_container = click_area(
                         container(
                             row![
                                 svg(utils::get_image_dir().join("paperclip.svg"))
@@ -206,7 +207,7 @@ pub fn c_chat_message<'a>(
                         })
                         .padding(12),
                     )
-                    .on_release(Message::DownloadFile(file.clone()))
+                    .on_press(Message::DownloadFile(file.clone()))
                     .interaction(iced::mouse::Interaction::Pointer);
                     files_row = files_row.push(file_container);
                 }
@@ -266,7 +267,7 @@ pub fn c_chat_message<'a>(
                         .join(", ");
 
                     let reaction_container = tooltip(
-                        mouse_area(
+                        click_area(
                             container(row![reaction_text, text(reacters)].spacing(4))
                                 .style(move |_| {
                                     if self_has_reacted {
@@ -297,7 +298,7 @@ pub fn c_chat_message<'a>(
                                 })
                                 .align_y(Alignment::Center),
                         )
-                        .on_release(Message::EmotionClicked(
+                        .on_press(Message::EmotionClicked(
                             message.id.clone().unwrap(),
                             reaction.clone(),
                         ))
@@ -334,7 +335,7 @@ pub fn c_chat_message<'a>(
     if are_reactions {
         reactions_row = reactions_row.push({
             let content = tooltip(
-                mouse_area(
+                click_area(
                     container(
                         svg(utils::get_image_dir().join("plus.svg"))
                             .width(19)
@@ -354,7 +355,7 @@ pub fn c_chat_message<'a>(
                     }),
                 )
                 .interaction(iced::mouse::Interaction::Pointer)
-                .on_release(Message::TogglePlusEmojiPicker(message.id.clone().unwrap())),
+                .on_press(Message::TogglePlusEmojiPicker(message.id.clone().unwrap())),
                 c_tooltip(theme, "Add Reaction"),
                 Position::Top,
             );
@@ -429,12 +430,12 @@ pub fn c_chat_message<'a>(
                             container(space())
                         },
                         tooltip(
-                            mouse_area(
+                            click_area(
                                 svg(utils::get_image_dir().join("reply.svg"))
                                     .width(21)
                                     .height(21)
                             )
-                            .on_release(Message::Reply(
+                            .on_press(Message::Reply(
                                 message.content.clone(),
                                 message.im_display_name.clone(),
                                 message.id.clone(),
@@ -446,12 +447,12 @@ pub fn c_chat_message<'a>(
                         space().width(6),
                         {
                             let content = tooltip(
-                                mouse_area(
+                                click_area(
                                     svg(utils::get_image_dir().join("plus.svg"))
                                         .width(21)
                                         .height(21),
                                 )
-                                .on_release(
+                                .on_press(
                                     Message::ToggleMessageEmojiPicker(message.id.clone().unwrap()),
                                 ),
                                 c_tooltip(theme, "React"),
@@ -486,12 +487,12 @@ pub fn c_chat_message<'a>(
                         space().width(6),
                         {
                             let content = tooltip(
-                                mouse_area(
+                                click_area(
                                     svg(utils::get_image_dir().join("ellipsis.svg"))
                                         .width(21)
                                         .height(21),
                                 )
-                                .on_release(
+                                .on_press(
                                     Message::ToggleShowMoreOptions(message.id.clone().unwrap()),
                                 ),
                                 c_tooltip(theme, "More"),
@@ -535,7 +536,7 @@ pub fn c_chat_message<'a>(
 
     let message_id_clone = message.id.clone();
     let message_stack = stack!(
-        mouse_area(
+        click_area(
             container(message_row)
                 .style(move |_| container::Style {
                     background: if (is_hovered

--- a/src/components/chat_message.rs
+++ b/src/components/chat_message.rs
@@ -535,8 +535,8 @@ pub fn c_chat_message<'a>(
     }
 
     let message_id_clone = message.id.clone();
-    let message_stack = stack!(
-        click_area(
+    let message_stack = click_area(
+        stack!(
             container(message_row)
                 .style(move |_| container::Style {
                     background: if (is_hovered
@@ -557,14 +557,14 @@ pub fn c_chat_message<'a>(
                     right: 1.0,
                     bottom: 4.0,
                     left: 3.0,
-                })
+                }),
+            action_container
         )
-        .on_enter(Message::ShowChatMessageOptions(message.id.clone().unwrap()))
-        .on_exit(Message::StopShowChatMessageOptions(
-            message.id.clone().unwrap()
-        )),
-        action_container
-    );
+    )
+    .on_enter(Message::ShowChatMessageOptions(message.id.clone().unwrap()))
+    .on_exit(Message::StopShowChatMessageOptions(
+        message.id.clone().unwrap()
+    ));
 
     return Some(message_stack.into());
 }

--- a/src/components/conversation.rs
+++ b/src/components/conversation.rs
@@ -1,4 +1,5 @@
-use iced::widget::{column, container, mouse_area, text};
+use crate::widgets::click_area::click_area;
+use iced::widget::{column, container, text};
 use iced::{Element, border};
 use indexmap::IndexMap;
 
@@ -49,7 +50,7 @@ pub fn c_conversation<'a>(
 
     if messages.len() > 1 {
         message_chain = message_chain.push(
-            mouse_area(
+            click_area(
                 text(if show_replies {
                     "Hide replies"
                 } else {
@@ -59,7 +60,7 @@ pub fn c_conversation<'a>(
                 .size(14),
             )
             .interaction(iced::mouse::Interaction::Pointer)
-            .on_release(Message::ToggleReplyOptions(conversation_id)),
+            .on_press(Message::ToggleReplyOptions(conversation_id)),
         );
     }
 

--- a/src/components/emoji_picker.rs
+++ b/src/components/emoji_picker.rs
@@ -2,7 +2,8 @@ use crate::components::horizontal_line::c_horizontal_line;
 use crate::style::Theme;
 use crate::types::Emoji;
 use crate::{Message, utils};
-use iced::widget::{Id, column, container, mouse_area, row, scrollable, svg, text, text_input};
+use crate::widgets::click_area::click_area;
+use iced::widget::{Id, column, container, row, scrollable, svg, text, text_input};
 use iced::{Border, Element, Length, Padding};
 use indexmap::IndexMap;
 
@@ -27,7 +28,7 @@ where
             let mut emoji_cat8 = row![];
 
             for (_emoji_id, emoji) in emoji_map {
-                let emoji_component = mouse_area(
+                let emoji_component = click_area(
                     container(
                         container(text(emoji.unicode.clone()).size(34))
                             .width(38)
@@ -36,7 +37,7 @@ where
                     .padding(2),
                 )
                 .interaction(iced::mouse::Interaction::Pointer)
-                .on_release(on_pick(_emoji_id.to_string(), emoji.unicode.clone()));
+                .on_press(on_pick(_emoji_id.to_string(), emoji.unicode.clone()));
 
                 match emoji.category.as_str() {
                     "People & Body" => emoji_cat1 = emoji_cat1.push(emoji_component),
@@ -76,7 +77,7 @@ where
                     s.to_lowercase()
                         .contains(search_emojis_input_value.to_lowercase().as_str())
                 }) {
-                    let emoji_component = mouse_area(
+                    let emoji_component = click_area(
                         container(
                             container(text(emoji.unicode.clone()).size(34))
                                 .width(38)
@@ -85,7 +86,7 @@ where
                         .padding(2),
                     )
                     .interaction(iced::mouse::Interaction::Pointer)
-                    .on_release(on_pick(_emoji_id.to_string(), emoji.unicode.clone()));
+                    .on_press(on_pick(_emoji_id.to_string(), emoji.unicode.clone()));
 
                     emoji_row = emoji_row.push(emoji_component);
                 }
@@ -107,69 +108,69 @@ where
 
     let categories = container(
         column![
-            mouse_area(
+            click_area(
                 svg(utils::get_image_dir().join("clock.svg"))
                     .width(24)
                     .height(24)
             )
             .interaction(iced::mouse::Interaction::Pointer)
-            .on_release(Message::EmojiPickerScrollTo(0.0)),
-            mouse_area(
+            .on_press(Message::EmojiPickerScrollTo(0.0)),
+            click_area(
                 svg(utils::get_image_dir().join("smile.svg"))
                     .width(24)
                     .height(24)
             )
             .interaction(iced::mouse::Interaction::Pointer)
-            .on_release(Message::EmojiPickerScrollTo(0.0)),
-            mouse_area(
+            .on_press(Message::EmojiPickerScrollTo(0.0)),
+            click_area(
                 svg(utils::get_image_dir().join("user-round.svg"))
                     .width(24)
                     .height(24)
             )
             .interaction(iced::mouse::Interaction::Pointer)
-            .on_release(Message::EmojiPickerScrollTo(0.1261)),
-            mouse_area(
+            .on_press(Message::EmojiPickerScrollTo(0.1261)),
+            click_area(
                 svg(utils::get_image_dir().join("leaf.svg"))
                     .width(24)
                     .height(24)
             )
             .interaction(iced::mouse::Interaction::Pointer)
-            .on_release(Message::EmojiPickerScrollTo(0.342)),
-            mouse_area(
+            .on_press(Message::EmojiPickerScrollTo(0.342)),
+            click_area(
                 svg(utils::get_image_dir().join("pizza.svg"))
                     .width(24)
                     .height(24)
             )
             .interaction(iced::mouse::Interaction::Pointer)
-            .on_release(Message::EmojiPickerScrollTo(0.45)),
-            mouse_area(
+            .on_press(Message::EmojiPickerScrollTo(0.45)),
+            click_area(
                 svg(utils::get_image_dir().join("gamepad-2.svg"))
                     .width(24)
                     .height(24)
             )
             .interaction(iced::mouse::Interaction::Pointer)
-            .on_release(Message::EmojiPickerScrollTo(0.53)),
-            mouse_area(
+            .on_press(Message::EmojiPickerScrollTo(0.53)),
+            click_area(
                 svg(utils::get_image_dir().join("bike.svg"))
                     .width(24)
                     .height(24)
             )
             .interaction(iced::mouse::Interaction::Pointer)
-            .on_release(Message::EmojiPickerScrollTo(0.59)),
-            mouse_area(
+            .on_press(Message::EmojiPickerScrollTo(0.59)),
+            click_area(
                 svg(utils::get_image_dir().join("lamp.svg"))
                     .width(24)
                     .height(24)
             )
             .interaction(iced::mouse::Interaction::Pointer)
-            .on_release(Message::EmojiPickerScrollTo(0.734)),
-            mouse_area(
+            .on_press(Message::EmojiPickerScrollTo(0.734)),
+            click_area(
                 svg(utils::get_image_dir().join("heart.svg"))
                     .width(24)
                     .height(24)
             )
             .interaction(iced::mouse::Interaction::Pointer)
-            .on_release(Message::EmojiPickerScrollTo(0.9)),
+            .on_press(Message::EmojiPickerScrollTo(0.9)),
         ]
         .height(Length::Fill)
         .spacing(8),
@@ -206,7 +207,7 @@ where
     )
     .padding(12);
 
-    mouse_area(
+    click_area(
         container(column![
             top_part,
             c_horizontal_line(theme, Length::Fill),

--- a/src/components/expanded_image.rs
+++ b/src/components/expanded_image.rs
@@ -2,7 +2,8 @@ use crate::Message;
 use crate::widgets::gif::Gif;
 use directories::ProjectDirs;
 use iced::Element;
-use iced::widget::{container, image, mouse_area};
+use crate::widgets::click_area::click_area;
+use iced::widget::{container, image};
 
 pub fn c_expanded_image<'a>(identifier: &String, image_type: &String) -> Element<'a, Message> {
     let project_dirs = ProjectDirs::from("", "ianterzo", "squads");
@@ -10,7 +11,7 @@ pub fn c_expanded_image<'a>(identifier: &String, image_type: &String) -> Element
     image_path.push("image-cache");
     image_path.push(format!("{}.{}", identifier, image_type));
 
-    mouse_area(if image_type == "gif" {
+    click_area(if image_type == "gif" {
         container(Gif::new(image_path))
     } else {
         container(image(image_path))

--- a/src/components/message.rs
+++ b/src/components/message.rs
@@ -8,7 +8,8 @@ use crate::types::Emoji;
 use crate::websockets::Presence;
 use crate::widgets::anchored_overlay::anchored_overlay;
 use crate::{style, utils};
-use iced::widget::{column, container, mouse_area, row, svg, text, tooltip};
+use crate::widgets::click_area::click_area;
+use iced::widget::{column, container, row, svg, text, tooltip};
 use iced::{Alignment, Border, Element, Font, Padding, border, font};
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -250,7 +251,7 @@ pub fn c_message<'a>(
                         .join(", ");
 
                     let reaction_container = tooltip(
-                        mouse_area(
+                        click_area(
                             container(row![reaction_text, text(reacters)].spacing(4))
                                 .style(move |_| {
                                     if self_has_reacted {
@@ -281,7 +282,7 @@ pub fn c_message<'a>(
                                 })
                                 .align_y(Alignment::Center),
                         )
-                        .on_release(Message::EmotionClicked(
+                        .on_press(Message::EmotionClicked(
                             message.id.clone().unwrap(),
                             reaction.clone(),
                         ))
@@ -312,7 +313,7 @@ pub fn c_message<'a>(
 
         let message_id_clone = message.id.clone().unwrap();
         let add_reaction_container = {
-            let content = mouse_area(
+            let content = click_area(
                 container(row![text("+")].spacing(4).padding(Padding::from([0, 3])))
                     .style(|_| container::Style {
                         background: Some(theme.colors.foreground_surface.into()),
@@ -322,7 +323,7 @@ pub fn c_message<'a>(
                     .padding(3)
                     .align_y(Alignment::Center),
             )
-            .on_release(Message::TogglePlusEmojiPicker(message.id.clone().unwrap()))
+            .on_press(Message::TogglePlusEmojiPicker(message.id.clone().unwrap()))
             .interaction(iced::mouse::Interaction::Pointer);
 
             if *show_plus_emoji_picker && *emoji_picker_message_id == message.id.clone() {
@@ -364,7 +365,7 @@ pub fn c_message<'a>(
                 let mut files_row = row![].spacing(10);
 
                 for file in files {
-                    let file_container = mouse_area(
+                    let file_container = click_area(
                         container(
                             row![
                                 svg(utils::get_image_dir().join("paperclip.svg"))
@@ -383,7 +384,7 @@ pub fn c_message<'a>(
                         })
                         .padding(12),
                     )
-                    .on_release(Message::DownloadFile(file.clone()))
+                    .on_press(Message::DownloadFile(file.clone()))
                     .interaction(iced::mouse::Interaction::Pointer);
 
                     files_row = files_row.push(file_container);

--- a/src/components/message_area.rs
+++ b/src/components/message_area.rs
@@ -1,6 +1,7 @@
 use iced::widget::text_editor::Content;
+use crate::widgets::click_area::click_area;
 use iced::widget::{
-    column, container, mouse_area, rich_text, row, space, span, svg, text, text_editor, text_input,
+    column, container, rich_text, row, space, span, svg, text, text_editor, text_input,
     tooltip,
 };
 use iced::{Alignment, Border, Element, Font, Length, Padding, border, font, padding};
@@ -68,12 +69,12 @@ pub fn c_message_area<'a>(
                         row![
                             {
                                 let content = tooltip(
-                                    mouse_area(
+                                    click_area(
                                         svg(utils::get_image_dir().join("smile.svg"))
                                             .width(19)
                                             .height(19),
                                     )
-                                    .on_release(Message::ToggleMessageAreaEmojiPicker)
+                                    .on_press(Message::ToggleMessageAreaEmojiPicker)
                                     .interaction(iced::mouse::Interaction::Pointer),
                                     c_tooltip(theme, "Emojis"),
                                     tooltip::Position::Top,
@@ -99,12 +100,12 @@ pub fn c_message_area<'a>(
                                 }
                             },
                             tooltip(
-                                mouse_area(
+                                click_area(
                                     svg(utils::get_image_dir().join("upload.svg"))
                                         .width(19)
                                         .height(19)
                                 )
-                                .on_release(Message::UploadFile)
+                                .on_press(Message::UploadFile)
                                 .interaction(iced::mouse::Interaction::Pointer),
                                 c_tooltip(theme, "Upload File"),
                                 tooltip::Position::Top
@@ -115,14 +116,14 @@ pub fn c_message_area<'a>(
                             row![
                                 row![
                                     tooltip(
-                                        mouse_area(
+                                        click_area(
                                             rich_text![span::<(), Font>("B").font(Font {
                                                 weight: font::Weight::Bold,
                                                 ..Default::default()
                                             })]
                                             .size(20)
                                         )
-                                        .on_release(Message::MessageAreaAction(
+                                        .on_press(Message::MessageAreaAction(
                                             MessageAreaAction::Bold
                                         ))
                                         .interaction(iced::mouse::Interaction::Pointer),
@@ -130,14 +131,14 @@ pub fn c_message_area<'a>(
                                         tooltip::Position::Top
                                     ),
                                     tooltip(
-                                        mouse_area(
+                                        click_area(
                                             rich_text![span::<(), Font>("I").font(Font {
                                                 style: font::Style::Italic,
                                                 ..Default::default()
                                             })]
                                             .size(20)
                                         )
-                                        .on_release(Message::MessageAreaAction(
+                                        .on_press(Message::MessageAreaAction(
                                             MessageAreaAction::Italic
                                         ))
                                         .interaction(iced::mouse::Interaction::Pointer),
@@ -145,11 +146,11 @@ pub fn c_message_area<'a>(
                                         tooltip::Position::Top
                                     ),
                                     tooltip(
-                                        mouse_area(
+                                        click_area(
                                             rich_text![span::<(), Font>("U").underline(true)]
                                                 .size(20)
                                         )
-                                        .on_release(Message::MessageAreaAction(
+                                        .on_press(Message::MessageAreaAction(
                                             MessageAreaAction::Underline
                                         ))
                                         .interaction(iced::mouse::Interaction::Pointer),
@@ -157,11 +158,11 @@ pub fn c_message_area<'a>(
                                         tooltip::Position::Top
                                     ),
                                     tooltip(
-                                        mouse_area(
+                                        click_area(
                                             rich_text![span::<(), Font>("S").strikethrough(true)]
                                                 .size(20)
                                         )
-                                        .on_release(Message::MessageAreaAction(
+                                        .on_press(Message::MessageAreaAction(
                                             MessageAreaAction::Striketrough
                                         ))
                                         .interaction(iced::mouse::Interaction::Pointer),
@@ -172,12 +173,12 @@ pub fn c_message_area<'a>(
                                 .spacing(8),
                                 row![
                                     tooltip(
-                                        mouse_area(
+                                        click_area(
                                             svg(utils::get_image_dir().join("list.svg"))
                                                 .width(23)
                                                 .height(23)
                                         )
-                                        .on_release(Message::MessageAreaAction(
+                                        .on_press(Message::MessageAreaAction(
                                             MessageAreaAction::List
                                         ))
                                         .interaction(iced::mouse::Interaction::Pointer),
@@ -185,12 +186,12 @@ pub fn c_message_area<'a>(
                                         tooltip::Position::Top
                                     ),
                                     tooltip(
-                                        mouse_area(
+                                        click_area(
                                             svg(utils::get_image_dir().join("list-ordered.svg"))
                                                 .width(23)
                                                 .height(23)
                                         )
-                                        .on_release(Message::MessageAreaAction(
+                                        .on_press(Message::MessageAreaAction(
                                             MessageAreaAction::OrderedList
                                         ))
                                         .interaction(iced::mouse::Interaction::Pointer),
@@ -202,12 +203,12 @@ pub fn c_message_area<'a>(
                                 .spacing(8),
                                 row![
                                     tooltip(
-                                        mouse_area(
+                                        click_area(
                                             svg(utils::get_image_dir().join("code.svg"))
                                                 .width(23)
                                                 .height(23)
                                         )
-                                        .on_release(Message::MessageAreaAction(
+                                        .on_press(Message::MessageAreaAction(
                                             MessageAreaAction::Code
                                         ))
                                         .interaction(iced::mouse::Interaction::Pointer),
@@ -215,12 +216,12 @@ pub fn c_message_area<'a>(
                                         tooltip::Position::Top
                                     ),
                                     tooltip(
-                                        mouse_area(
+                                        click_area(
                                             svg(utils::get_image_dir().join("text-quote.svg"))
                                                 .width(23)
                                                 .height(23)
                                         )
-                                        .on_release(Message::MessageAreaAction(
+                                        .on_press(Message::MessageAreaAction(
                                             MessageAreaAction::Blockquote
                                         ))
                                         .interaction(iced::mouse::Interaction::Pointer),
@@ -228,12 +229,12 @@ pub fn c_message_area<'a>(
                                         tooltip::Position::Top
                                     ),
                                     tooltip(
-                                        mouse_area(
+                                        click_area(
                                             svg(utils::get_image_dir().join("link.svg"))
                                                 .width(19)
                                                 .height(19)
                                         )
-                                        .on_release(Message::MessageAreaAction(
+                                        .on_press(Message::MessageAreaAction(
                                             MessageAreaAction::Link
                                         ))
                                         .interaction(iced::mouse::Interaction::Pointer),
@@ -241,12 +242,12 @@ pub fn c_message_area<'a>(
                                         tooltip::Position::Top
                                     ),
                                     tooltip(
-                                        mouse_area(
+                                        click_area(
                                             svg(utils::get_image_dir().join("image.svg"))
                                                 .width(19)
                                                 .height(19)
                                         )
-                                        .on_release(Message::MessageAreaAction(
+                                        .on_press(Message::MessageAreaAction(
                                             MessageAreaAction::Image
                                         ))
                                         .interaction(iced::mouse::Interaction::Pointer),
@@ -273,7 +274,7 @@ pub fn c_message_area<'a>(
                         if let Page::Team(_, _) = page {
                             if subject_input_content.is_none() {
                                 container(
-                                    mouse_area(
+                                    click_area(
                                         container(
                                             row![
                                                 svg(utils::get_image_dir().join("plus.svg"))
@@ -286,12 +287,12 @@ pub fn c_message_area<'a>(
                                         )
                                         .padding(4),
                                     )
-                                    .on_release(Message::AddSubject)
+                                    .on_press(Message::AddSubject)
                                     .interaction(iced::mouse::Interaction::Pointer),
                                 )
                             } else {
                                 container(
-                                    mouse_area(
+                                    click_area(
                                         container(
                                             row![
                                                 svg(utils::get_image_dir().join("minus.svg"))
@@ -305,7 +306,7 @@ pub fn c_message_area<'a>(
                                         )
                                         .padding(4),
                                     )
-                                    .on_release(Message::RemoveSubject)
+                                    .on_press(Message::RemoveSubject)
                                     .interaction(iced::mouse::Interaction::Pointer),
                                 )
                             }
@@ -318,7 +319,7 @@ pub fn c_message_area<'a>(
                             space()
                         },
                         container(
-                            mouse_area(
+                            click_area(
                                 container(
                                     row![
                                         svg(utils::get_image_dir().join("corner-down-right.svg"))
@@ -331,7 +332,7 @@ pub fn c_message_area<'a>(
                                 )
                                 .padding(4)
                             )
-                            .on_release(Message::PostMessage)
+                            .on_press(Message::PostMessage)
                             .interaction(iced::mouse::Interaction::Pointer)
                         ),
                     ])

--- a/src/components/more_options.rs
+++ b/src/components/more_options.rs
@@ -4,7 +4,8 @@ use crate::parsing::get_html_preview;
 use crate::utils;
 use crate::{Message, style};
 use iced::alignment::Vertical;
-use iced::widget::{column, container, mouse_area, row, space, svg, text};
+use crate::widgets::click_area::click_area;
+use iced::widget::{column, container, row, space, svg, text};
 use iced::{Border, Element};
 
 pub fn c_more_options<'a>(
@@ -12,10 +13,10 @@ pub fn c_more_options<'a>(
     message: crate::api::Message,
     me: &Profile,
 ) -> Element<'a, Message> {
-    mouse_area(
+    click_area(
         container(column![
             column![
-                mouse_area(
+                click_area(
                     row![
                         svg(utils::get_image_dir().join("smile.svg"))
                             .width(19)
@@ -26,11 +27,11 @@ pub fn c_more_options<'a>(
                     .spacing(8)
                 )
                 .interaction(iced::mouse::Interaction::Pointer)
-                .on_release(Message::ToggleMessageEmojiPicker(
+                .on_press(Message::ToggleMessageEmojiPicker(
                     message.id.clone().unwrap()
                 )),
                 c_horizontal_line(theme, 200.into()),
-                mouse_area(
+                click_area(
                     row![
                         svg(utils::get_image_dir().join("reply.svg"))
                             .width(19)
@@ -41,12 +42,12 @@ pub fn c_more_options<'a>(
                     .spacing(8)
                 )
                 .interaction(iced::mouse::Interaction::Pointer)
-                .on_release(Message::Reply(
+                .on_press(Message::Reply(
                     message.content.clone(),
                     message.im_display_name.clone(),
                     message.id.clone(),
                 )),
-                mouse_area(
+                click_area(
                     row![
                         svg(utils::get_image_dir().join("copy.svg"))
                             .width(19)
@@ -57,7 +58,7 @@ pub fn c_more_options<'a>(
                     .spacing(8)
                 )
                 .interaction(iced::mouse::Interaction::Pointer)
-                .on_release(Message::CopyText(
+                .on_press(Message::CopyText(
                     if let Some(content) = message.content.clone() {
                         if let Some(message_type) = message.message_type.clone() {
                             if message_type == "RichText/Html" {
@@ -89,7 +90,7 @@ pub fn c_more_options<'a>(
                     if let Some(properties) = message.properties
                         && properties.deletetime > 0
                     {
-                        mouse_area(
+                        click_area(
                             row![
                                 svg(utils::get_image_dir().join("rotate-ccw.svg"))
                                     .width(19)
@@ -100,9 +101,9 @@ pub fn c_more_options<'a>(
                             .spacing(8),
                         )
                         .interaction(iced::mouse::Interaction::Pointer)
-                        .on_release(Message::Restore(message.id.clone()))
+                        .on_press(Message::Restore(message.id.clone()))
                     } else {
-                        mouse_area(
+                        click_area(
                             row![
                                 svg(utils::get_image_dir().join("trash.svg"))
                                     .width(19)
@@ -113,7 +114,7 @@ pub fn c_more_options<'a>(
                             .spacing(8),
                         )
                         .interaction(iced::mouse::Interaction::Pointer)
-                        .on_release(Message::Delete(message.id.clone()))
+                        .on_press(Message::Delete(message.id.clone()))
                     }
                 ]
                 .spacing(12)

--- a/src/components/profile.rs
+++ b/src/components/profile.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use iced::alignment::Vertical;
-use iced::widget::{column, container, mouse_area, row, svg, text};
+use crate::widgets::click_area::click_area;
+use iced::widget::{column, container, row, svg, text};
 use iced::{Border, Element, Font, Padding, border, font};
 
 use crate::Message;
@@ -32,7 +33,7 @@ pub fn c_profile<'a>(
 
     let presence = user_presences.get(&me.id);
 
-    mouse_area(
+    click_area(
         container(
             column![
                 row![

--- a/src/components/sidebar.rs
+++ b/src/components/sidebar.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 
 use iced::alignment::Vertical;
 use iced::widget::svg::Handle;
+use crate::widgets::click_area::{ClickArea, click_area};
 use iced::widget::{
-    MouseArea, column, container, mouse_area, row, scrollable, space, svg, text, tooltip,
+    column, container, row, scrollable, space, svg, text, tooltip,
 };
 use iced::{Alignment, Border, Element, Length, Padding, padding};
 
@@ -64,7 +65,7 @@ pub fn c_sidebar<'a>(
                 container(space().width(4).height(38))
             },
             tooltip(
-                MouseArea::new(c_cached_image(
+                ClickArea::new(c_cached_image(
                     team.picture_e_tag
                         .clone()
                         .unwrap_or(team.display_name.clone()),
@@ -80,7 +81,7 @@ pub fn c_sidebar<'a>(
                     36.0,
                     4.0,
                 ))
-                .on_release(Message::OpenTeam(team.id.clone(), team.id.clone()))
+                .on_press(Message::OpenTeam(team.id.clone(), team.id.clone()))
                 .on_enter(Message::PrefetchTeam(team.id.clone(), team.id.clone()))
                 .interaction(iced::mouse::Interaction::Pointer),
                 container(text(&team.display_name).wrapping(text::Wrapping::WordOrGlyph))
@@ -149,13 +150,13 @@ pub fn c_sidebar<'a>(
                         },
                         tooltip(
                             container(
-                                mouse_area(
+                                click_area(
                                     svg(utils::get_image_dir().join("message-square.svg"))
                                         .width(23)
                                         .height(23),
                                 )
                                 .on_enter(Message::PrefetchCurrentChat)
-                                .on_release(Message::OpenCurrentChat)
+                                .on_press(Message::OpenCurrentChat)
                                 .interaction(iced::mouse::Interaction::Pointer)
                             ),
                             container(text("Direct Messages"))
@@ -188,12 +189,12 @@ pub fn c_sidebar<'a>(
                         },
                         tooltip(
                             container(
-                                mouse_area(
+                                click_area(
                                     svg(utils::get_image_dir().join("bell.svg"))
                                         .width(23)
                                         .height(23),
                                 )
-                                .on_release(Message::OpenActivity)
+                                .on_press(Message::OpenActivity)
                                 .interaction(iced::mouse::Interaction::Pointer)
                             ),
                             container(text("Activity"))
@@ -223,7 +224,7 @@ pub fn c_sidebar<'a>(
                 ],
                 team_scrollbar,
                 column![c_horizontal_line(&theme, 38.into()), {
-                    let content = mouse_area(
+                    let content = click_area(
                         container(c_picture_and_status(
                             theme,
                             user_picture,
@@ -237,7 +238,7 @@ pub fn c_sidebar<'a>(
                             right: 0.0,
                         }),
                     )
-                    .on_release(Message::ToggleShowProfile);
+                    .on_press(Message::ToggleShowProfile);
 
                     if *show_profile {
                         anchored_overlay(

--- a/src/components/start_chat.rs
+++ b/src/components/start_chat.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
 use crate::{Message, api::Profile, style::Theme};
+use crate::widgets::click_area::click_area;
 use iced::{
     Border, Element, Length, Padding,
     alignment::Vertical,
     border,
-    widget::{Id, column, container, mouse_area, scrollable, text, text_input},
+    widget::{Id, column, container, scrollable, text, text_input},
 };
 
 pub fn c_start_chat<'a>(
@@ -57,7 +58,7 @@ pub fn c_start_chat<'a>(
 
         user_column = user_column
             .push(
-                mouse_area(
+                click_area(
                     container(profile_row)
                         .style(move |_| container::Style {
                             // If relevant user is none make the first user of users highlighted
@@ -81,14 +82,14 @@ pub fn c_start_chat<'a>(
                 )
                 .interaction(iced::mouse::Interaction::Pointer)
                 .on_enter(Message::SetStartChatRelevantUser(user.0.clone()))
-                .on_release(Message::StartChat(vec![user.0.clone()])),
+                .on_press(Message::StartChat(vec![user.0.clone()])),
             )
             .into();
 
         is_first_user = false;
     }
 
-    mouse_area(
+    click_area(
         container(
             column![
                 container(

--- a/src/pages/page_activity.rs
+++ b/src/pages/page_activity.rs
@@ -11,8 +11,8 @@ use crate::websockets::Presence;
 use iced::Element;
 use iced::Length;
 use iced::Padding;
+use crate::widgets::click_area::click_area;
 use iced::widget::container;
-use iced::widget::mouse_area;
 use iced::widget::{column, scrollable, text};
 use indexmap::IndexMap;
 
@@ -68,7 +68,7 @@ pub fn activity<'a>(
                         );
                         if let Some(message) = message {
                             activities_colum = activities_colum.push(
-                                mouse_area(message).on_release(Message::ToggleExpandActivity(
+                                click_area(message).on_press(Message::ToggleExpandActivity(
                                     thread_id,
                                     message_id,
                                     message_activity_id,
@@ -77,7 +77,7 @@ pub fn activity<'a>(
                         }
                     } else {
                         activities_colum = activities_colum.push(
-                            mouse_area(text("Failed to load conversation.")).on_release(
+                            click_area(text("Failed to load conversation.")).on_press(
                                 Message::ToggleExpandActivity(
                                     thread_id,
                                     message_id,
@@ -88,13 +88,13 @@ pub fn activity<'a>(
                     }
                 } else {
                     activities_colum = activities_colum.push(
-                        mouse_area(c_preview_message(
+                        click_area(c_preview_message(
                             theme,
                             activity,
                             &window_size.0,
                             emoji_map,
                         ))
-                        .on_release(Message::ToggleExpandActivity(
+                        .on_press(Message::ToggleExpandActivity(
                             thread_id,
                             message_id,
                             message_activity_id,
@@ -103,13 +103,13 @@ pub fn activity<'a>(
                 }
             } else {
                 activities_colum = activities_colum.push(
-                    mouse_area(c_preview_message(
+                    click_area(c_preview_message(
                         theme,
                         activity,
                         &window_size.0,
                         emoji_map,
                     ))
-                    .on_release(Message::ToggleExpandActivity(
+                    .on_press(Message::ToggleExpandActivity(
                         thread_id,
                         message_id,
                         message_activity_id,

--- a/src/pages/page_chat.rs
+++ b/src/pages/page_chat.rs
@@ -18,7 +18,8 @@ use crate::{ChatBody, style};
 use iced::alignment::Vertical;
 use iced::task::Handle;
 use iced::widget::text_editor::Content;
-use iced::widget::{Id, column, container, mouse_area, row, space, svg, tooltip};
+use crate::widgets::click_area::click_area;
+use iced::widget::{Id, column, container, row, space, svg, tooltip};
 use iced::widget::{scrollable, text};
 use iced::{Alignment, Color, Element, Length, Padding, border, padding};
 use indexmap::IndexMap;
@@ -231,7 +232,7 @@ pub fn chat<'a>(
 
         chat_items = chat_items.push(chat_info_column);
 
-        let chat_item = mouse_area(
+        let chat_item = click_area(
             container(chat_items)
                 .style(move |_| {
                     if let Some(current_chat) = current_chat {
@@ -271,7 +272,7 @@ pub fn chat<'a>(
         )
         .on_enter(Message::PrefetchChat(chat.id.clone()))
         .on_exit(Message::StopShowChatListOptions(chat.id.clone()))
-        .on_release(Message::OpenChat(chat.id.clone()))
+        .on_press(Message::OpenChat(chat.id.clone()))
         .interaction(iced::mouse::Interaction::Pointer);
 
         chats_column = chats_column.push(chat_item);
@@ -289,9 +290,9 @@ pub fn chat<'a>(
     let chat_options = column![
         container(
             container(
-                mouse_area(text("Start or find a chat"))
+                click_area(text("Start or find a chat"))
                     .interaction(iced::mouse::Interaction::Pointer)
-                    .on_release(Message::ToggleNewChatMenu)
+                    .on_press(Message::ToggleNewChatMenu)
             )
             .padding(Padding {
                 top: 5.0,
@@ -355,23 +356,23 @@ pub fn chat<'a>(
             container(
                 row![
                     tooltip(
-                        mouse_area(
+                        click_area(
                             svg(utils::get_image_dir().join("users-round.svg"))
                                 .width(19)
                                 .height(19)
                         )
-                        .on_release(Message::ToggleShowChatMembers)
+                        .on_press(Message::ToggleShowChatMembers)
                         .interaction(iced::mouse::Interaction::Pointer),
                         c_tooltip(theme, "Show Member List"),
                         tooltip::Position::Bottom
                     ),
                     tooltip(
-                        mouse_area(
+                        click_area(
                             svg(utils::get_image_dir().join("user-round-plus.svg"))
                                 .width(19)
                                 .height(19)
                         )
-                        .on_release(Message::ToggleShowChatAdd)
+                        .on_press(Message::ToggleShowChatAdd)
                         .interaction(iced::mouse::Interaction::Pointer),
                         c_tooltip(theme, "Add Users to DM"),
                         tooltip::Position::Bottom

--- a/src/pages/page_team.rs
+++ b/src/pages/page_team.rs
@@ -9,7 +9,8 @@ use crate::websockets::Presence;
 use directories::ProjectDirs;
 use iced::alignment::{Horizontal, Vertical};
 use iced::widget::text_editor::Content;
-use iced::widget::{Column, Id, column, container, mouse_area, row, scrollable, space, text};
+use crate::widgets::click_area::click_area;
+use iced::widget::{Column, Id, column, container, row, scrollable, space, text};
 use iced::{Element, Length, Padding, border, font, padding};
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -198,7 +199,7 @@ pub fn team<'a>(
         let page_channel_cloned = page_channel.clone();
         let channel_cloned = channel.clone();
         channels_coloumn = channels_coloumn.push(
-            mouse_area(
+            click_area(
                 container(text(truncate_name(channel.display_name, 16)))
                     .style(move |_| {
                         if channel_cloned.id == page_channel_cloned.id {
@@ -236,7 +237,7 @@ pub fn team<'a>(
             )
             .on_enter(Message::PrefetchTeam(team.id.clone(), channel.id.clone()))
             .on_exit(Message::StopShowChannelListOptions(channel.id.clone()))
-            .on_release(Message::OpenTeam(team.id.clone(), channel.id))
+            .on_press(Message::OpenTeam(team.id.clone(), channel.id))
             .interaction(iced::mouse::Interaction::Pointer),
         );
     }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -14,7 +14,7 @@ use iced::Color;
 use iced::border;
 use iced::mouse;
 use iced::padding;
-use iced::widget::mouse_area;
+use crate::widgets::click_area::click_area;
 use iced::widget::space;
 use iced::widget::span;
 use iced::widget::{Column, Container, Row, column, container, row, text};
@@ -368,14 +368,14 @@ fn transform_html<'a>(
                             image_width = image_width * factor;
                         }
 
-                        let team_picture = mouse_area(c_cached_image(
+                        let team_picture = click_area(c_cached_image(
                             identifier.clone(),
                             Message::AuthorizeImage(image_url, identifier.clone()),
                             image_width,
                             image_height,
                             8.0,
                         ))
-                        .on_release(Message::ExpandImage(identifier, "jpeg".to_string()))
+                        .on_press(Message::ExpandImage(identifier, "jpeg".to_string()))
                         .interaction(mouse::Interaction::Pointer);
 
                         dynamic_container = dynamic_container.push(team_picture.into());
@@ -395,13 +395,13 @@ fn transform_html<'a>(
                                 let height = height.parse().unwrap();
                                 image_height = height;
                             }
-                            let team_picture = mouse_area(c_cached_gif(
+                            let team_picture = click_area(c_cached_gif(
                                 identifier.clone(),
                                 Message::DownloadImage(image_url.to_string(), identifier.clone()),
                                 image_width,
                                 image_height,
                             ))
-                            .on_release(Message::ExpandImage(identifier, "gif".to_string()))
+                            .on_press(Message::ExpandImage(identifier, "gif".to_string()))
                             .interaction(mouse::Interaction::Pointer);
                             dynamic_container = dynamic_container.push(team_picture.into());
                         } else {

--- a/src/widgets/click_area.rs
+++ b/src/widgets/click_area.rs
@@ -175,7 +175,6 @@ where
                         if cursor.is_over(bounds) {
                             shell.publish(on_press.clone());
                         }
-                        shell.capture_event();
                     }
                 }
             }

--- a/src/widgets/click_area.rs
+++ b/src/widgets/click_area.rs
@@ -1,0 +1,255 @@
+use iced::advanced::{
+    Clipboard, Layout, Shell, Widget, layout, mouse, overlay, renderer, widget,
+};
+use iced::{Element, Event, Length, Point, Rectangle, Renderer, Size, Vector};
+use iced::touch;
+
+use crate::Theme;
+
+pub fn click_area<'a, Message: 'a>(
+    content: impl Into<Element<'a, Message>>,
+) -> ClickArea<'a, Message> {
+    ClickArea::new(content)
+}
+
+pub struct ClickArea<'a, Message> {
+    content: Element<'a, Message>,
+    on_press: Option<Message>,
+    on_enter: Option<Message>,
+    on_exit: Option<Message>,
+    interaction: Option<mouse::Interaction>,
+}
+
+#[derive(Default)]
+struct State {
+    is_hovered: bool,
+    is_pressed: bool,
+    bounds: Rectangle,
+    cursor_position: Option<Point>,
+}
+
+impl<'a, Message> ClickArea<'a, Message> {
+    pub fn new(content: impl Into<Element<'a, Message>>) -> Self {
+        ClickArea {
+            content: content.into(),
+            on_press: None,
+            on_enter: None,
+            on_exit: None,
+            interaction: None,
+        }
+    }
+
+    pub fn on_press(mut self, message: Message) -> Self {
+        self.on_press = Some(message);
+        self
+    }
+
+    pub fn on_enter(mut self, message: Message) -> Self {
+        self.on_enter = Some(message);
+        self
+    }
+
+    pub fn on_exit(mut self, message: Message) -> Self {
+        self.on_exit = Some(message);
+        self
+    }
+
+    pub fn interaction(mut self, interaction: mouse::Interaction) -> Self {
+        self.interaction = Some(interaction);
+        self
+    }
+}
+
+impl<Message> Widget<Message, Theme, Renderer> for ClickArea<'_, Message>
+where
+    Message: Clone,
+{
+    fn tag(&self) -> widget::tree::Tag {
+        widget::tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> widget::tree::State {
+        widget::tree::State::new(State::default())
+    }
+
+    fn children(&self) -> Vec<widget::Tree> {
+        vec![widget::Tree::new(&self.content)]
+    }
+
+    fn diff(&self, tree: &mut widget::Tree) {
+        tree.diff_children(std::slice::from_ref(&self.content));
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.content.as_widget().size()
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut widget::Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.content
+            .as_widget_mut()
+            .layout(&mut tree.children[0], renderer, limits)
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut widget::Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn widget::Operation<()>,
+    ) {
+        self.content
+            .as_widget_mut()
+            .operate(&mut tree.children[0], layout, renderer, operation);
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut widget::Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        self.content.as_widget_mut().update(
+            &mut tree.children[0],
+            event,
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        );
+
+        if shell.is_event_captured() {
+            return;
+        }
+
+        let state = tree.state.downcast_mut::<State>();
+        let bounds = layout.bounds();
+        let cursor_position = cursor.position();
+
+        if state.cursor_position != cursor_position || state.bounds != bounds {
+            let was_hovered = state.is_hovered;
+            state.is_hovered = cursor.is_over(bounds);
+            state.cursor_position = cursor_position;
+            state.bounds = bounds;
+
+            match (&self.on_enter, &self.on_exit) {
+                (Some(on_enter), _) if state.is_hovered && !was_hovered => {
+                    shell.publish(on_enter.clone());
+                }
+                (_, Some(on_exit)) if !state.is_hovered && was_hovered => {
+                    shell.publish(on_exit.clone());
+                }
+                _ => {}
+            }
+        }
+
+        match event {
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                if self.on_press.is_some() && cursor.is_over(bounds) {
+                    state.is_pressed = true;
+                    shell.capture_event();
+                }
+            }
+            Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                if state.is_pressed && !cursor.is_over(bounds) {
+                    state.is_pressed = false;
+                }
+            }
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerLifted { .. }) => {
+                if let Some(on_press) = &self.on_press {
+                    if state.is_pressed {
+                        state.is_pressed = false;
+                        if cursor.is_over(bounds) {
+                            shell.publish(on_press.clone());
+                        }
+                        shell.capture_event();
+                    }
+                }
+            }
+            Event::Touch(touch::Event::FingerLost { .. }) => {
+                state.is_pressed = false;
+            }
+            _ => {}
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        _tree: &widget::Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+        _renderer: &Renderer,
+    ) -> mouse::Interaction {
+        if let Some(interaction) = self.interaction {
+            if cursor.is_over(layout.bounds()) {
+                return interaction;
+            }
+        }
+        if cursor.is_over(layout.bounds()) && self.on_press.is_some() {
+            mouse::Interaction::Pointer
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn draw(
+        &self,
+        tree: &widget::Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.content.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            style,
+            layout,
+            cursor,
+            viewport,
+        );
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut widget::Tree,
+        layout: Layout<'b>,
+        renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        self.content.as_widget_mut().overlay(
+            &mut tree.children[0],
+            layout,
+            renderer,
+            viewport,
+            translation,
+        )
+    }
+}
+
+impl<'a, Message> From<ClickArea<'a, Message>> for Element<'a, Message>
+where
+    Message: Clone + 'a,
+{
+    fn from(click_area: ClickArea<'a, Message>) -> Self {
+        Element::new(click_area)
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,6 +1,7 @@
 pub mod anchored_overlay;
 pub mod centered_overlay;
 pub mod circle;
+pub mod click_area;
 pub mod gif;
 pub mod selectable_rich_text;
 pub mod selectable_text;


### PR DESCRIPTION
Replace mouse_area with click_area, require press+release on same element

Clicks now require both mouse-down and mouse-up to land on the same 
element. Drag-out while held cancels the press entirely.

Before: `mouse_area().on_release()` fired whenever cursor was over 
the widget at release time, even if the press started elsewhere.

After: `click_area().on_press()` fires only when press originated 
inside the widget AND release lands inside the same widget.

_AI assisted coding_ 